### PR TITLE
feat: 自動バグ修正デモ記事の公開準備 - 関連リンクを絶対URLに統一

### DIFF
--- a/articles/article-2-bug-fix-demo.md
+++ b/articles/article-2-bug-fix-demo.md
@@ -1,9 +1,9 @@
 ---
 title: "PlayWrightとTaskMasterで TODOアプリの自動バグ修正デモ - 驚きの仕組みを試してみた！"
-emoji: "🔧"
+emoji: "🤩"
 type: "tech"
 topics: ["playwright", "taskmaster", "cursor", "AI駆動開発", "テスト自動化"]
-published: false
+published: true
 ---
 
 :::message alert
@@ -20,6 +20,8 @@ published: false
 :::
 
 ## はじめに
+
+こんにちは ⭐️ ソフトウェアエンジニアを目指して修行中の Yuki です！
 
 最近、開発TMのリーダーにPlayWrightのデモを見せてもらったことをきっかけに、自分でもUI自動構築のデモを作りたくなっていろいろ試行錯誤してみました。初心者なりに試してみた結果、興味深い発見があったので、その体験を共有してみます。
 
@@ -157,7 +159,7 @@ this.fixSteps.forEach((step, index) => {
 
 ### パフォーマンスとセキュリティ例
 
-- **検出時間**: 高速（1秒間隔）
+- **検出時間**: 高速
 - **修正時間**: 即座
 - **総処理時間**: 8秒以内
 - **セキュリティ**: XSS対策、入力検証、安全なDOM操作
@@ -196,8 +198,8 @@ this.fixSteps.forEach((step, index) => {
 
 ## 関連記事
 
-- [修行中エンジニアがAIツールを試してみたら想像以上にすごかった体験談](ai-development-automation-story.md)
-- [PlayWrightとTaskMasterで TODOアプリの自動構築デモ - 驚きの仕組みを調べてみた！](article-1-auto-build-demo.md)
+- [修行中エンジニアがAIツールを試してみたら想像以上にすごかった体験談](https://zenn.dev/yucco/articles/ai-development-automation-story)
+- [PlayWrightとTaskMasterで TODOアプリの自動構築デモ - 驚きの仕組みを調べてみた！](https://zenn.dev/yucco/articles/article-1-auto-build-demo)
 
 ## 実際に試してみよう！
 


### PR DESCRIPTION
## 変更内容

- 自動バグ修正デモ記事（article-2-bug-fix-demo.md）の関連リンクを絶対URLに統一
- 記事の公開設定を有効化（published: true）
- 絵文字を🔧から🤩に変更
- 冒頭に自己紹介文を追加
- パフォーマンス説明の表現を緩和

## 関連記事
- [修行中エンジニアがAIツールを試してみたら想像以上にすごかった体験談](https://zenn.dev/yucco/articles/ai-development-automation-story)
- [PlayWrightとTaskMasterで TODOアプリの自動構築デモ](https://zenn.dev/yucco/articles/article-1-auto-build-demo)

## 公開順序
この記事はAI開発技術ブログシリーズの第3弾として公開予定です。

## 関連イシュー
Closes #11