### PR TITLE
秘書づくり記事を公開状態に変更

### DIFF
--- a/articles/personal-ai-secretary-automation.md
+++ b/articles/personal-ai-secretary-automation.md
@@ -3,7 +3,7 @@ title: "未読1000件から始めた、自分専用の秘書づくり ―― 身
 emoji: "📬"
 type: "tech"
 topics: ["ai", "自動化", "gmail", "カレンダー", "github"]
-published: false
+published: true
 ---
 
 :::message


### PR DESCRIPTION
## Summary
- articles/personal-ai-secretary-automation.md の `published` を `false` から `true` に変更
- PR #21 でマージ済みの記事本文について、内容確認後に公開する対応

## Test plan
- [ ] Zennプレビューで公開状態として表示されることを確認